### PR TITLE
Update headers for OpenH264 2.1.0

### DIFF
--- a/codec/api/svc/codec_app_def.h
+++ b/codec/api/svc/codec_app_def.h
@@ -167,8 +167,8 @@ typedef enum {
   DECODER_OPTION_LEVEL,                 ///< get current AU level info,only is used in GetOption
   DECODER_OPTION_STATISTICS_LOG_INTERVAL,///< set log output interval
   DECODER_OPTION_IS_REF_PIC,             ///< feedback current frame is ref pic or not
-  DECODER_OPTION_NUM_OF_FRAMES_REMAINING_IN_BUFFER  ///< number of frames remaining in decoder buffer when pictures are required to re-ordered into display-order.
-
+  DECODER_OPTION_NUM_OF_FRAMES_REMAINING_IN_BUFFER,  ///< number of frames remaining in decoder buffer when pictures are required to re-ordered into display-order.
+  DECODER_OPTION_NUM_OF_THREADS,         ///< number of decoding threads. The maximum thread count is equal or less than lesser of (cpu core counts and 16).
 } DECODER_OPTION;
 
 /**

--- a/codec/api/svc/codec_def.h
+++ b/codec/api/svc/codec_def.h
@@ -201,6 +201,7 @@ typedef struct TagBufferInfo {
   union {
     SSysMEMBuffer sSystemBuffer; ///<  memory info for one picture
   } UsrData;                     ///<  output buffer info
+  unsigned char* pDst[3];  //point to picture YUV data
 } SBufferInfo;
 
 

--- a/codec/api/svc/codec_ver.h
+++ b/codec/api/svc/codec_ver.h
@@ -4,12 +4,12 @@
 
 #include "codec_app_def.h"
 
-static const OpenH264Version g_stCodecVersion  = {2, 0, 0, 1905};
-static const char* const g_strCodecVer  = "OpenH264 version:2.0.0.1905";
+static const OpenH264Version g_stCodecVersion  = {2, 1, 0, 2002};
+static const char* const g_strCodecVer  = "OpenH264 version:2.1.0.2002";
 
 #define OPENH264_MAJOR (2)
-#define OPENH264_MINOR (0)
+#define OPENH264_MINOR (1)
 #define OPENH264_REVISION (0)
-#define OPENH264_RESERVED (1905)
+#define OPENH264_RESERVED (2002)
 
 #endif  // CODEC_VER_H

--- a/meson.build
+++ b/meson.build
@@ -9,7 +9,7 @@ project('noopenh264', ['cpp'],
 )
 
 major_version = '5'
-matching_version = '2.0.0'
+matching_version = '2.1.0'
 
 pkgconfig = import('pkgconfig')
 


### PR DESCRIPTION
ABI with 2.1.0 and compatibility is broken both ways. This can result in crashes unless handled with care.

https://phabricator.endlessm.com/T29880