### PR TITLE
Add plumbing to add openh264 runtime to library search path when available

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+noopenh264 (2.1.1-1endless1) eos; urgency=medium
+
+  * d/rules: Install ld.so.conf config file and links to the openh264 flatpak
+    runtime - only on Endless based systems
+  * d/libnoopenh264-6.dirs: Add, ship ld.so.conf config file
+  * d/libnoopenh264-6.links: Add, ship links to openh264 flatpak runtime -
+    only on selected architectures
+  * d/runtime-org.freedesktop.Platform.openh264.conf.in: Add, ld.so.conf
+    config file
+  * https://phabricator.endlessm.com/T23316
+
+ -- Andre Moreira Magalhaes <andre.magalhaes@endlessos.org>  Wed, 03 Mar 2021 17:35:13 -0300
+
 noopenh264 (2.1.1) eos; urgency=medium
 
   * Update to match new upstream version and soname.

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Endless <support@endlessm.com>
 Homepage: https://github.com/endlessm/noopenh264
 Standards-Version: 4.3.0
-Build-Depends: debhelper-compat (= 12), meson
+Build-Depends: debhelper-compat (= 13), meson
 
 Package: libnoopenh264-6
 Architecture: any

--- a/debian/libnoopenh264-6.dirs
+++ b/debian/libnoopenh264-6.dirs
@@ -1,0 +1,1 @@
+etc/ld.so.conf.d

--- a/debian/libnoopenh264-6.links
+++ b/debian/libnoopenh264-6.links
@@ -1,0 +1,4 @@
+#!/usr/bin/dh-exec
+[linux-amd64] /var/lib/flatpak/runtime/org.freedesktop.Platform.openh264/x86_64/2.0/active/files/extra/libopenh264.so.6 /usr/lib/${DEB_HOST_MULTIARCH}/openh264/extra/libopenh264.so.6
+[linux-arm64] /var/lib/flatpak/runtime/org.freedesktop.Platform.openh264/aarch64/2.0/active/files/extra/libopenh264.so.6 /usr/lib/${DEB_HOST_MULTIARCH}/openh264/extra/libopenh264.so.6
+[linux-arm linux-armel linux-armhf] /var/lib/flatpak/runtime/org.freedesktop.Platform.openh264/arm/2.0/active/files/extra/libopenh264.so.6 /usr/lib/${DEB_HOST_MULTIARCH}/openh264/extra/libopenh264.so.6

--- a/debian/rules
+++ b/debian/rules
@@ -1,5 +1,27 @@
 #!/usr/bin/make -f
 # -*- makefile -*-
 
+DEBIAN_DIST := $(shell lsb_release -ds | tr -d '()' | sed -e 's/\#/ /g')
+
+ifneq (,$(findstring Endless,$(DEBIAN_DIST)))
+debian/runtime-org.freedesktop.Platform.openh264.conf: debian/runtime-org.freedesktop.Platform.openh264.conf.in
+	### configure
+	sed -e 's/@DEB_HOST_MULTIARCH@/$(DEB_HOST_MULTIARCH)/g' \
+		$< > $@
+
+override_dh_install: debian/runtime-org.freedesktop.Platform.openh264.conf
+	mkdir -p debian/libnoopenh264-6/etc/ld.so.conf.d/
+	install -m 755 debian/runtime-org.freedesktop.Platform.openh264.conf debian/libnoopenh264-6/etc/ld.so.conf.d/
+	dh_install
+
+override_dh_clean:
+	rm -f debian/runtime-org.freedesktop.Platform.openh264.conf
+else
+# Do not install /etc/ld.so.conf.d and flatpak runtime links when not on Endless
+override_dh_link:
+
+override_dh_installdirs:
+endif
+
 %:
 	dh $@

--- a/debian/runtime-org.freedesktop.Platform.openh264.conf.in
+++ b/debian/runtime-org.freedesktop.Platform.openh264.conf.in
@@ -1,0 +1,1 @@
+/usr/lib/@DEB_HOST_MULTIARCH@/openh264/extra

--- a/meson.build
+++ b/meson.build
@@ -48,7 +48,8 @@ pkg_install_dir = '@0@/pkgconfig'.format(get_option('libdir'))
 foreach t : ['', '-static']
   pkgconf = configuration_data()
   pkgconf.set('prefix', join_paths(get_option('prefix')))
-  pkgconf.set('VERSION', meson.project_version())
+  pkgconf.set('libdir', libdir)
+  pkgconf.set('VERSION', matching_version)
   if t == '-static'
     do_install = false
     pkgconf.set('LIBS', '-lstdc++ -lpthread -lm')

--- a/openh264.pc.in
+++ b/openh264.pc.in
@@ -1,8 +1,8 @@
 prefix=@prefix@
-libdir=${prefix}/lib
+libdir=@libdir@
 includedir=${prefix}/include
 
-Name: NoOpenH264
+Name: OpenH264
 Description: Dummy implementation of the OpenH264 library from Cisco.
 Version: @VERSION@
 Libs: -L${libdir} -lopenh264 @LIBS@


### PR DESCRIPTION
Add links to the openh264 flatpak runtime at $LIBDIR/openh264/extra and a ld.so.conf config file to make this dir available in the library search path.
    
This change is Endless specific for now as this package may be used in other distros that don't want this behaviour - If you prefer we could move this change to some other package but I think this is as good as any tbh.

I also imported [a patch from freedesktop-sdk](https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/blob/master/patches/noopenh264/make-version-same-as-actual-lib.patch) to fix the pkgconfig file (required to build gst-plugins-bad against it).
    
https://phabricator.endlessm.com/T23316
