### PR TITLE
Revert changes to add plumbing to openh264 flatpak runtime

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+noopenh264 (2.1.1-2) eos; urgency=medium
+
+  * Revert changes to add plumbing to openh264 flatpak runtime, this is
+    now moved to a separate package:
+    https://phabricator.endlessm.com/T23316
+
+ -- Andre Moreira Magalhaes <andre.magalhaes@endlessos.org>  Mon, 15 Mar 2021 17:07:11 -0300
+
 noopenh264 (2.1.1-1endless1) eos; urgency=medium
 
   * d/rules: Install ld.so.conf config file and links to the openh264 flatpak

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Endless <support@endlessm.com>
 Homepage: https://github.com/endlessm/noopenh264
 Standards-Version: 4.3.0
-Build-Depends: debhelper-compat (= 13), dh-exec, meson
+Build-Depends: debhelper-compat (= 13), meson
 
 Package: libnoopenh264-6
 Architecture: any

--- a/debian/libnoopenh264-6.dirs
+++ b/debian/libnoopenh264-6.dirs
@@ -1,1 +1,0 @@
-etc/ld.so.conf.d

--- a/debian/libnoopenh264-6.links
+++ b/debian/libnoopenh264-6.links
@@ -1,4 +1,0 @@
-#!/usr/bin/dh-exec
-[linux-amd64] /var/lib/flatpak/runtime/org.freedesktop.Platform.openh264/x86_64/2.0/active/files/extra/libopenh264.so.6 /usr/lib/${DEB_HOST_MULTIARCH}/openh264/extra/libopenh264.so.6
-[linux-arm64] /var/lib/flatpak/runtime/org.freedesktop.Platform.openh264/aarch64/2.0/active/files/extra/libopenh264.so.6 /usr/lib/${DEB_HOST_MULTIARCH}/openh264/extra/libopenh264.so.6
-[linux-arm linux-armel linux-armhf] /var/lib/flatpak/runtime/org.freedesktop.Platform.openh264/arm/2.0/active/files/extra/libopenh264.so.6 /usr/lib/${DEB_HOST_MULTIARCH}/openh264/extra/libopenh264.so.6

--- a/debian/rules
+++ b/debian/rules
@@ -1,27 +1,5 @@
 #!/usr/bin/make -f
 # -*- makefile -*-
 
-DEBIAN_DIST := "$(shell dpkg-vendor --query vendor)"
-
-ifeq ($(DEBIAN_DIST),"Endless")
-debian/runtime-org.freedesktop.Platform.openh264.conf: debian/runtime-org.freedesktop.Platform.openh264.conf.in
-	### configure
-	sed -e 's/@DEB_HOST_MULTIARCH@/$(DEB_HOST_MULTIARCH)/g' \
-		$< > $@
-
-override_dh_install: debian/runtime-org.freedesktop.Platform.openh264.conf
-	mkdir -p debian/libnoopenh264-6/etc/ld.so.conf.d/
-	install -m 755 debian/runtime-org.freedesktop.Platform.openh264.conf debian/libnoopenh264-6/etc/ld.so.conf.d/
-	dh_install
-
-override_dh_clean:
-	rm -f debian/runtime-org.freedesktop.Platform.openh264.conf
-else
-# Do not install /etc/ld.so.conf.d and flatpak runtime links when not on Endless
-override_dh_link:
-
-override_dh_installdirs:
-endif
-
 %:
 	dh $@

--- a/debian/runtime-org.freedesktop.Platform.openh264.conf.in
+++ b/debian/runtime-org.freedesktop.Platform.openh264.conf.in
@@ -1,1 +1,0 @@
-/usr/lib/@DEB_HOST_MULTIARCH@/openh264/extra


### PR DESCRIPTION
This is now moved to a separate package.

https://phabricator.endlessm.com/T23316