### PR TITLE
Revert back to version 2.2.0 and sync the headers.

### DIFF
--- a/codec/api/svc/codec_ver.h
+++ b/codec/api/svc/codec_ver.h
@@ -4,12 +4,12 @@
 
 #include "codec_app_def.h"
 
-static const OpenH264Version g_stCodecVersion  = {2, 1, 1, 2005};
-static const char* const g_strCodecVer  = "OpenH264 version:2.1.1.2005";
+static const OpenH264Version g_stCodecVersion  = {2, 2, 0, 2201};
+static const char* const g_strCodecVer  = "OpenH264 version:2.2.0.2201";
 
 #define OPENH264_MAJOR (2)
-#define OPENH264_MINOR (1)
-#define OPENH264_REVISION (1)
-#define OPENH264_RESERVED (2005)
+#define OPENH264_MINOR (2)
+#define OPENH264_REVISION (0)
+#define OPENH264_RESERVED (2201)
 
 #endif  // CODEC_VER_H

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+noopenh264 (2.2.0) eos; urgency=medium
+
+  * Downgrade to 2.2.0, since 2.3.0 included a breaking change to
+    SEncParamExt.
+
+ -- Will Thompson <wjt@endlessos.org>  Mon, 12 Sep 2022 16:01:58 +0100
+
 noopenh264 (2.3.0) eos; urgency=medium
 
   * Update to match new upstream version.

--- a/meson.build
+++ b/meson.build
@@ -9,7 +9,7 @@ project('noopenh264', ['cpp'],
 )
 
 major_version = '6'
-matching_version = '2.3.0'
+matching_version = '2.2.0'
 
 pkgconfig = import('pkgconfig')
 


### PR DESCRIPTION
Version 2.3.0 added new fields to the `SEncParamExt` Struct breaking api. Thus we need to revert back to using version 2.2.0, as well as to sync the `codec_ver.h` header.

This PR replaces #10 

https://phabricator.endlessm.com/T33476