### PR TITLE
debian: Avoid version number going backwards

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-noopenh264 (2.2.0) eos; urgency=medium
+noopenh264 (2.3.0+really2.2.0) eos; urgency=medium
 
   * Downgrade to 2.2.0, since 2.3.0 included a breaking change to
     SEncParamExt.


### PR DESCRIPTION
I previously just YOLOed this with the intention of messing with our apt repo, but I think I can do better, by creating a
Version_2.3.0+really2.2.0 tag...

https://phabricator.endlessm.com/T33476